### PR TITLE
fix: Allow blocks to intersect

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -101,19 +101,24 @@ module.exports = inherit({
                     return;
                 }
 
+                const handled = new Set();
+
                 var lines = content.split(/\r?\n/g);
                 // cover into <pre> blocks css lines having some coverage state
                 for (var b = blocks.length - 1; b >= 0; b--) {
                     var block = blocks[b];
 
                     for (var l = block.start.line - 1; l < block.end.line; l++) {
-                        lines[l] = '<pre class="' + block.type + '">' + htmlEscape(lines[l]) + ' </pre>';
+                        if (!handled.has(l)) {
+                            lines[l] = '<pre class="' + block.type + '">' + htmlEscape(lines[l]) + ' </pre>';
+                            handled.add(l);
+                        }
                     }
                 }
 
                 // cover into <pre> blocks everything not covered in the state above
-                lines = lines.map(function(line) {
-                    return /^<\/?pre/.test(line) ? line : '<pre>' + htmlEscape(line) + ' </pre>';
+                lines = lines.map(function(line, lineNo) {
+                    return handled.has(lineNo) ? line : '<pre>' + htmlEscape(line) + ' </pre>';
                 });
 
                 return qfs.write(dest, hb.compile(opts.tmpl)({


### PR DESCRIPTION
When using preprocessor, it is possible that multiple rules will map to
the same lines. In that case, the corresponding lines in the report will
be wrapped multiple times.